### PR TITLE
SocketNodeClient: Prevent connection timeout

### DIFF
--- a/src/VASSAL/chat/node/SocketNodeClient.java
+++ b/src/VASSAL/chat/node/SocketNodeClient.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Properties;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import VASSAL.chat.CgiServerStatus;
 import VASSAL.chat.WelcomeMessageServer;
@@ -61,6 +63,17 @@ public class SocketNodeClient extends NodeClient implements SocketWatcher {
     Socket s = new Socket(serverInfo.getHostName(), serverInfo.getPort());
     sender = new BufferedSocketHandler(s, this);
     sender.start();
+
+    Timer timer = new Timer();
+
+    timer.scheduleAtFixedRate(new TimerTask() {
+	    @Override
+	    public void run() {
+		sender.writeLine("");
+	    }
+	},
+	2*60*1000,
+	2*60*1000);
 
   }
 


### PR DESCRIPTION
Connections to the vassal legacy server would timeout periodically after leaving vassal engine idle for up to an half an hour.  

I saw this forum post about a similar issue:
http://www.vassalengine.org/forum/viewtopic.php?t=9485
This PR basically does what Malnorma suggested as their workaround. 

It sends a blank message to the server, every 2 minutes. 
Ensuring that the connection remains alive.
